### PR TITLE
Added a Google Doc Light Theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 extension
 extension.zip
+leetcode-custom-themes.code-workspace

--- a/popup.html
+++ b/popup.html
@@ -20,8 +20,7 @@
     <div class="box custom-select">
       <select id="theme">
         <option selected disabled>Choose Theme</option>
-        <option value="cm-s-google-doc-light">Google Interview Day</option>
-        <option value="cm-s-google-doc-light">Google Interview Night</option>
+        <option value="cm-s-google-interview-day">Google Interview Day</option>
         <option value="cm-s-3024-day">3024 Day</option>
         <option value="cm-s-3024-night">3024 Night</option>
         <option value="cm-s-abbott">Abbott</option>

--- a/popup.html
+++ b/popup.html
@@ -21,6 +21,7 @@
       <select id="theme">
         <option selected disabled>Choose Theme</option>
         <option value="cm-s-google-interview-day">Google Interview Day</option>
+        <option value="cm-s-google-interview-night">Google Interview Night</option>
         <option value="cm-s-3024-day">3024 Day</option>
         <option value="cm-s-3024-night">3024 Night</option>
         <option value="cm-s-abbott">Abbott</option>

--- a/popup.html
+++ b/popup.html
@@ -41,6 +41,7 @@
         <option value="cm-s-eclipse">Eclipse</option>
         <option value="cm-s-elegant">Elegant</option>
         <option value="cm-s-erlang-dark">Erlang Dark</option>
+        <option value="cm-s-google-doc-light">Google Doc Light</option>
         <option value="cm-s-gruvbox-dark">Gruvbox Dark</option>
         <option value="cm-s-hopscotch">Hopscotch</option>
         <option value="cm-s-icecoder">Icecoder</option>

--- a/popup.html
+++ b/popup.html
@@ -20,6 +20,8 @@
     <div class="box custom-select">
       <select id="theme">
         <option selected disabled>Choose Theme</option>
+        <option value="cm-s-google-doc-light">Google Interview Day</option>
+        <option value="cm-s-google-doc-light">Google Interview Night</option>
         <option value="cm-s-3024-day">3024 Day</option>
         <option value="cm-s-3024-night">3024 Night</option>
         <option value="cm-s-abbott">Abbott</option>
@@ -41,7 +43,6 @@
         <option value="cm-s-eclipse">Eclipse</option>
         <option value="cm-s-elegant">Elegant</option>
         <option value="cm-s-erlang-dark">Erlang Dark</option>
-        <option value="cm-s-google-doc-light">Google Doc Light</option>
         <option value="cm-s-gruvbox-dark">Gruvbox Dark</option>
         <option value="cm-s-hopscotch">Hopscotch</option>
         <option value="cm-s-icecoder">Icecoder</option>

--- a/styles.js
+++ b/styles.js
@@ -7,11 +7,11 @@ var google_interview_day = `/*
     Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
 */
 
-.cm-s-google-interview-day.CodeMirror { background: red; color: black; }
-.cm-s-google-interview-day div.CodeMirror-selected { background: blue; }
+.cm-s-google-interview-day.CodeMirror { background: #f7f7f7; color: black; }
+.cm-s-google-interview-day div.CodeMirror-selected { background: #33CCFF; }
 
-.cm-s-google-interview-day .CodeMirror-line::selection, .cm-s-3024-day .CodeMirror-line > span::selection, .cm-s-3024-day .CodeMirror-line > span > span::selection { background: #d6d5d4; }
-.cm-s-google-interview-day .CodeMirror-line::-moz-selection, .cm-s-3024-day .CodeMirror-line > span::-moz-selection, .cm-s-3024-day .CodeMirror-line > span > span::selection { background: #d9d9d9; }
+.cm-s-google-interview-day .CodeMirror-line::selection, .cm-s-google-interview-day .CodeMirror-line > span::selection, .cm-s-google-interview-day .CodeMirror-line > span > span::selection { background: #d6d5d4; }
+.cm-s-google-interview-day .CodeMirror-line::-moz-selection, .cm-s-google-interview-day .CodeMirror-line > span::-moz-selection, .cm-s-google-interview-day .CodeMirror-line > span > span::selection { background: #d9d9d9; }
 
 .cm-s-google-interview-day .CodeMirror-gutters { background: #f7f7f7; border-right: 0px; }
 .cm-s-google-interview-day .CodeMirror-guttermarker { color: black; }
@@ -24,7 +24,7 @@ var google_interview_day = `/*
 .cm-s-google-interview-day span.cm-atom { color: black; }
 .cm-s-google-interview-day span.cm-number { color: black; }
 
-.cm-s-google-interview-day span.cm-property, .cm-s-3024-day span.cm-attribute { color: black; }
+.cm-s-google-interview-day span.cm-property, .cm-s-google-interview-day span.cm-attribute { color: black; }
 .cm-s-google-interview-day span.cm-keyword { color: black; }
 .cm-s-google-interview-day span.cm-string { color: black; }
 
@@ -3745,6 +3745,7 @@ var zenburn = `/**
 `;
 
 var styles = {
+    "cm-s-google-interview-day": google_interview_day,
     "cm-s-3024-day": _3024_day,
     "cm-s-3024-night": _3024_night,
     "cm-s-abbott": abbott,
@@ -3766,7 +3767,6 @@ var styles = {
     "cm-s-eclipse": eclipse,
     "cm-s-elegant": elegant,
     "cm-s-erlang-dark": erlang_dark,
-    "cm-s-google-interview-day": google_interview_day,
     "cm-s-gruvbox-dark": gruvbox_dark,
     "cm-s-hopscotch": hopscotch,
     "cm-s-icecoder": icecoder,

--- a/styles.js
+++ b/styles.js
@@ -1,6 +1,6 @@
 var google_interview_day = `/*
 
-    Name:       google-interview-day
+    Name:       Google Interview Day
     Author:     Edmund Leibert III (https://github.com/edmund-leibert)
 
     CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
@@ -38,6 +38,46 @@ var google_interview_day = `/*
 
 .cm-s-google-interview-day .CodeMirror-activeline-background { background: #e8f2ff; }
 .cm-s-google-interview-day .CodeMirror-matchingbracket { text-decoration: underline; color: black !important; }
+`;
+var google_interview_night = `/*
+
+    Name:       Google Interview Night
+    Author:     Jan T. Sott (http://github.com/idleberg)
+
+    CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
+    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+
+*/
+
+  .cm-s-google-interview-night.CodeMirror { background: #090300; color: white; }
+  .cm-s-google-interview-night div.CodeMirror-selected { background: #3a3432; }
+  .cm-s-google-interview-night .CodeMirror-line::selection, .cm-s-google-interview-night .CodeMirror-line > span::selection, .cm-s-google-interview-night .CodeMirror-line > span > span::selection { background: rgba(58, 52, 50, .99); }
+  .cm-s-google-interview-night .CodeMirror-line::-moz-selection, .cm-s-google-interview-night .CodeMirror-line > span::-moz-selection, .cm-s-google-interview-night .CodeMirror-line > span > span::-moz-selection { background: rgba(58, 52, 50, .99); }
+  .cm-s-google-interview-night .CodeMirror-gutters { background: #090300; border-right: 0px; }
+  .cm-s-google-interview-night .CodeMirror-guttermarker { color: #db2d20; }
+  .cm-s-google-interview-night .CodeMirror-guttermarker-subtle { color: #5c5855; }
+  .cm-s-google-interview-night .CodeMirror-linenumber { color: #5c5855; }
+  
+  .cm-s-google-interview-night .CodeMirror-cursor { border-left: 1px solid #807d7c; }
+  
+  .cm-s-google-interview-night span.cm-comment { color: white; }
+  .cm-s-google-interview-night span.cm-atom { color: white; }
+  .cm-s-google-interview-night span.cm-number { color: white; }
+  
+  .cm-s-google-interview-night span.cm-property, .cm-s-google-interview-night span.cm-attribute { color: white; }
+  .cm-s-google-interview-night span.cm-keyword { color: white; }
+  .cm-s-google-interview-night span.cm-string { color: white; }
+  
+  .cm-s-google-interview-night span.cm-variable { color: white; }
+  .cm-s-google-interview-night span.cm-variable-2 { color: white; }
+  .cm-s-google-interview-night span.cm-def { color: white; }
+  .cm-s-google-interview-night span.cm-bracket { color: white; }
+  .cm-s-google-interview-night span.cm-tag { color: white; }
+  .cm-s-google-interview-night span.cm-link { color: white; }
+  .cm-s-google-interview-night span.cm-error { background: #db2d20; color: white; }
+  
+  .cm-s-google-interview-night .CodeMirror-activeline-background { background: #2F2F2F; }
+  .cm-s-google-interview-night .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
 `;
 var _3024_day = `/*
 
@@ -3746,6 +3786,7 @@ var zenburn = `/**
 
 var styles = {
     "cm-s-google-interview-day": google_interview_day,
+    "cm-s-google-interview-night": google_interview_night,
     "cm-s-3024-day": _3024_day,
     "cm-s-3024-night": _3024_night,
     "cm-s-abbott": abbott,

--- a/styles.js
+++ b/styles.js
@@ -1003,6 +1003,48 @@ var erlang_dark = `.cm-s-erlang-dark.CodeMirror { background: #002240; color: wh
 .cm-s-erlang-dark .CodeMirror-activeline-background { background: #013461; }
 .cm-s-erlang-dark .CodeMirror-matchingbracket { outline:1px solid grey; color:white !important; }
 `;
+var google_doc_light = `/*
+
+    Name:       google-doc-light
+    Author:     Edmund Leibert III (https://github.com/edmund-leibert)
+
+    CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
+    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+
+*/
+
+.cm-s-3024-day.CodeMirror { background: #f7f7f7; color: black; }
+.cm-s-3024-day div.CodeMirror-selected { background: #d6d5d4; }
+
+.cm-s-3024-day .CodeMirror-line::selection, .cm-s-3024-day .CodeMirror-line > span::selection, .cm-s-3024-day .CodeMirror-line > span > span::selection { background: #d6d5d4; }
+.cm-s-3024-day .CodeMirror-line::-moz-selection, .cm-s-3024-day .CodeMirror-line > span::-moz-selection, .cm-s-3024-day .CodeMirror-line > span > span::selection { background: #d9d9d9; }
+
+.cm-s-3024-day .CodeMirror-gutters { background: #f7f7f7; border-right: 0px; }
+.cm-s-3024-day .CodeMirror-guttermarker { color: black; }
+.cm-s-3024-day .CodeMirror-guttermarker-subtle { color: black; }
+.cm-s-3024-day .CodeMirror-linenumber { color: #807d7c; }
+
+.cm-s-3024-day .CodeMirror-cursor { border-left: 1px solid #5c5855; }
+
+.cm-s-3024-day span.cm-comment { color: black; }
+.cm-s-3024-day span.cm-atom { color: black; }
+.cm-s-3024-day span.cm-number { color: black; }
+
+.cm-s-3024-day span.cm-property, .cm-s-3024-day span.cm-attribute { color: black; }
+.cm-s-3024-day span.cm-keyword { color: black; }
+.cm-s-3024-day span.cm-string { color: black; }
+
+.cm-s-3024-day span.cm-variable { color: black; }
+.cm-s-3024-day span.cm-variable-2 { color: black; }
+.cm-s-3024-day span.cm-def { color: black; }
+.cm-s-3024-day span.cm-bracket { color: black; }
+.cm-s-3024-day span.cm-tag { color: black; }
+.cm-s-3024-day span.cm-link { color: black; }
+.cm-s-3024-day span.cm-error { background: #db2d20; color: black; }
+
+.cm-s-3024-day .CodeMirror-activeline-background { background: #e8f2ff; }
+.cm-s-3024-day .CodeMirror-matchingbracket { text-decoration: underline; color: black !important; }
+`;
 var gruvbox_dark = `/*
 
     Name:       gruvbox-dark
@@ -3725,6 +3767,7 @@ var styles = {
     "cm-s-eclipse": eclipse,
     "cm-s-elegant": elegant,
     "cm-s-erlang-dark": erlang_dark,
+    "cm-s-google-doc-light": google_doc_light,
     "cm-s-gruvbox-dark": gruvbox_dark,
     "cm-s-hopscotch": hopscotch,
     "cm-s-icecoder": icecoder,

--- a/styles.js
+++ b/styles.js
@@ -1,3 +1,44 @@
+var google_interview_day = `/*
+
+    Name:       google-interview-day
+    Author:     Edmund Leibert III (https://github.com/edmund-leibert)
+
+    CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
+    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+*/
+
+.cm-s-google-interview-day.CodeMirror { background: red; color: black; }
+.cm-s-google-interview-day div.CodeMirror-selected { background: blue; }
+
+.cm-s-google-interview-day .CodeMirror-line::selection, .cm-s-3024-day .CodeMirror-line > span::selection, .cm-s-3024-day .CodeMirror-line > span > span::selection { background: #d6d5d4; }
+.cm-s-google-interview-day .CodeMirror-line::-moz-selection, .cm-s-3024-day .CodeMirror-line > span::-moz-selection, .cm-s-3024-day .CodeMirror-line > span > span::selection { background: #d9d9d9; }
+
+.cm-s-google-interview-day .CodeMirror-gutters { background: #f7f7f7; border-right: 0px; }
+.cm-s-google-interview-day .CodeMirror-guttermarker { color: black; }
+.cm-s-google-interview-day .CodeMirror-guttermarker-subtle { color: black; }
+.cm-s-google-interview-day .CodeMirror-linenumber { color: #807d7c; }
+
+.cm-s-google-interview-day .CodeMirror-cursor { border-left: 1px solid #5c5855; }
+
+.cm-s-google-interview-day span.cm-comment { color: black; }
+.cm-s-google-interview-day span.cm-atom { color: black; }
+.cm-s-google-interview-day span.cm-number { color: black; }
+
+.cm-s-google-interview-day span.cm-property, .cm-s-3024-day span.cm-attribute { color: black; }
+.cm-s-google-interview-day span.cm-keyword { color: black; }
+.cm-s-google-interview-day span.cm-string { color: black; }
+
+.cm-s-google-interview-day span.cm-variable { color: black; }
+.cm-s-google-interview-day span.cm-variable-2 { color: black; }
+.cm-s-google-interview-day span.cm-def { color: black; }
+.cm-s-google-interview-day span.cm-bracket { color: black; }
+.cm-s-google-interview-day span.cm-tag { color: black; }
+.cm-s-google-interview-day span.cm-link { color: black; }
+.cm-s-google-interview-day span.cm-error { background: #db2d20; color: black; }
+
+.cm-s-google-interview-day .CodeMirror-activeline-background { background: #e8f2ff; }
+.cm-s-google-interview-day .CodeMirror-matchingbracket { text-decoration: underline; color: black !important; }
+`;
 var _3024_day = `/*
 
     Name:       3024 day
@@ -1002,48 +1043,6 @@ var erlang_dark = `.cm-s-erlang-dark.CodeMirror { background: #002240; color: wh
 
 .cm-s-erlang-dark .CodeMirror-activeline-background { background: #013461; }
 .cm-s-erlang-dark .CodeMirror-matchingbracket { outline:1px solid grey; color:white !important; }
-`;
-var google_doc_light = `/*
-
-    Name:       google-doc-light
-    Author:     Edmund Leibert III (https://github.com/edmund-leibert)
-
-    CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
-    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
-
-*/
-
-.cm-s-3024-day.CodeMirror { background: #f7f7f7; color: black; }
-.cm-s-3024-day div.CodeMirror-selected { background: #d6d5d4; }
-
-.cm-s-3024-day .CodeMirror-line::selection, .cm-s-3024-day .CodeMirror-line > span::selection, .cm-s-3024-day .CodeMirror-line > span > span::selection { background: #d6d5d4; }
-.cm-s-3024-day .CodeMirror-line::-moz-selection, .cm-s-3024-day .CodeMirror-line > span::-moz-selection, .cm-s-3024-day .CodeMirror-line > span > span::selection { background: #d9d9d9; }
-
-.cm-s-3024-day .CodeMirror-gutters { background: #f7f7f7; border-right: 0px; }
-.cm-s-3024-day .CodeMirror-guttermarker { color: black; }
-.cm-s-3024-day .CodeMirror-guttermarker-subtle { color: black; }
-.cm-s-3024-day .CodeMirror-linenumber { color: #807d7c; }
-
-.cm-s-3024-day .CodeMirror-cursor { border-left: 1px solid #5c5855; }
-
-.cm-s-3024-day span.cm-comment { color: black; }
-.cm-s-3024-day span.cm-atom { color: black; }
-.cm-s-3024-day span.cm-number { color: black; }
-
-.cm-s-3024-day span.cm-property, .cm-s-3024-day span.cm-attribute { color: black; }
-.cm-s-3024-day span.cm-keyword { color: black; }
-.cm-s-3024-day span.cm-string { color: black; }
-
-.cm-s-3024-day span.cm-variable { color: black; }
-.cm-s-3024-day span.cm-variable-2 { color: black; }
-.cm-s-3024-day span.cm-def { color: black; }
-.cm-s-3024-day span.cm-bracket { color: black; }
-.cm-s-3024-day span.cm-tag { color: black; }
-.cm-s-3024-day span.cm-link { color: black; }
-.cm-s-3024-day span.cm-error { background: #db2d20; color: black; }
-
-.cm-s-3024-day .CodeMirror-activeline-background { background: #e8f2ff; }
-.cm-s-3024-day .CodeMirror-matchingbracket { text-decoration: underline; color: black !important; }
 `;
 var gruvbox_dark = `/*
 
@@ -3767,7 +3766,7 @@ var styles = {
     "cm-s-eclipse": eclipse,
     "cm-s-elegant": elegant,
     "cm-s-erlang-dark": erlang_dark,
-    "cm-s-google-doc-light": google_doc_light,
+    "cm-s-google-interview-day": google_interview_day,
     "cm-s-gruvbox-dark": gruvbox_dark,
     "cm-s-hopscotch": hopscotch,
     "cm-s-icecoder": icecoder,


### PR DESCRIPTION
Hello!

First and foremost, great job and I sincerely appreciate the extension that you made. It has been tremendously helpful so far.

I extended your original implementation to include a "Google Doc Light" theme in which there is **no** syntax highlighting (a.k.a. all syntax highlighting is black) to reflect the nature of a Google interview where you are expected to [write code on a Google Doc](https://www.teamblind.com/post/Google-interview--google-docs-DfH7GSfP).

Preview...
<img width="1199" alt="image" src="https://user-images.githubusercontent.com/43337293/192064442-8dce6bfc-4e39-4db9-8c21-93626268c8c2.png">


Thank you!